### PR TITLE
Fixed initializeProperties() to preserve Element objects

### DIFF
--- a/src/js/base/base.js
+++ b/src/js/base/base.js
@@ -10,7 +10,7 @@
             var key = keys[i];
             var enumerable = key.charCodeAt(0) !== /*_*/95;
             var member = members[key];
-            if (member && typeof member === 'object') {
+            if (member && typeof member === 'object' && !(member instanceof Element)) {
                 if (member.value !== undefined || typeof member.get === 'function' || typeof member.set === 'function') {
                     if (member.enumerable === undefined) {
                         member.enumerable = enumerable;


### PR DESCRIPTION
This fixes issue https://github.com/winjs/winjs/issues/39
