### PR TITLE
Edited derive and define Classes

### DIFF
--- a/src/js/base/base.js
+++ b/src/js/base/base.js
@@ -200,7 +200,11 @@
             /// The newly-defined class.
             /// </returns>
             /// </signature>
-            constructor = constructor || function () { };
+            if (typeof constructor !== 'function') {
+                staticMembers = instanceMembers || {};
+                instanceMembers = constructor || {};
+                constructor = function () { };
+            }
             WinJS.Utilities.markSupportedForProcessing(constructor);
             if (instanceMembers) {
                 initializeProperties(constructor.prototype, instanceMembers);
@@ -233,7 +237,11 @@
             /// </returns>
             /// </signature>
             if (baseClass) {
-                constructor = constructor || function () { };
+                if (typeof constructor !== 'function') {
+                    staticMembers = instanceMembers || {};
+                    instanceMembers = constructor || {};
+                    constructor = function () { };
+                }
                 var basePrototype = baseClass.prototype;
                 constructor.prototype = Object.create(basePrototype);
                 WinJS.Utilities.markSupportedForProcessing(constructor);


### PR DESCRIPTION
When you don't need to use a constructor is better don't pass anything
in constructor parameter.

Example before:
// normal Class
var a = WinJS.Class.define(constructor, instanceMembers, staticMembers);
// without constructor
var b = WinJS.Class.define(null, instanceMembers, staticMembers);

Example now:
// normal Class
var a = WinJS.Class.define(constructor, instanceMembers, staticMembers);
// without constructor
var b = WinJS.Class.define(instanceMembers, staticMembers);
