### PR TITLE
remove extraneous/unreferenced 'that' in datePicker, timePicker, Tooltip

### DIFF
--- a/src/js/controls/DatePicker/datePicker.js
+++ b/src/js/controls/DatePicker/datePicker.js
@@ -208,8 +208,6 @@
                 },
 
                 _createControls: function () {
-                    var that = this;
-
                     var info = this._information;
                     var index = info.getIndex(this.current);
 

--- a/src/js/controls/TimePicker/timePicker.js
+++ b/src/js/controls/TimePicker/timePicker.js
@@ -168,7 +168,6 @@
                         }
                     },
                     set: function (value) {
-                        var that = this;
                         var newTime;
                         if (typeof (value) === "string") {
                             newTime = WinJS.UI.TimePicker._sentinelDate();
@@ -337,8 +336,6 @@
                     }
 
                     this._addControlsInOrder(info);
-
-                    var that = this;
 
                     var hoursAmpm = this._getHoursAmpm(this.current);
                     this._hourControl = new WinJS.UI._Select(this._hourElement, {

--- a/src/js/controls/Tooltip/Tooltip.js
+++ b/src/js/controls/Tooltip/Tooltip.js
@@ -783,7 +783,6 @@
                     document.body.addEventListener("DOMNodeRemoved", this._removeTooltip, false);
                     this._createTooltipDOM();
                     var pos = this._position(contactType);
-                    var that = this;
                     if (this._useAnimation) {
                         animation.fadeIn(this._domElement)
                             .then(this._onShowAnimationEnd.bind(this));


### PR DESCRIPTION
There are a few cases where `var that = this` is defined but then is not referenced later on in the function.

`DateTime` unit tests pass on IE, and the relevant `controls` assertions do as well (although some unrelated ones are still failing; see https://github.com/winjs/winjs/issues/70).
