### PR TITLE
Export getValue to WinJS.Binding namespace

### DIFF
--- a/src/js/binding/declarative.js
+++ b/src/js/binding/declarative.js
@@ -666,6 +666,7 @@
         defaultBind: initializer(defaultBind),
         converter: converter,
         initializer: initializer,
+        getValue: getValue,
         setAttribute: initializer(setAttribute),
         setAttributeOneTime: initializer(setAttributeOneTime),
         addClassOneTime: initializer(addClassOneTime),

--- a/tests/binding/binding-decl.js
+++ b/tests/binding/binding-decl.js
@@ -2382,6 +2382,20 @@ CorsicaTests.BindingDeclTests = function () {
          then(complete, errorHandler);
 
     };
+    
+    this.testGetValue = function () {
+      var obj = {
+        title: "foo",
+        pages: {
+          page1: "bar"
+        }
+      }
+      LiveUnit.Assert.areEqual(WinJS.Binding.getValue(obj, "title", "foo"));
+      LiveUnit.Assert.areEqual(WinJS.Binding.getValue(obj, "pages.page1", "bar"));
+      LiveUnit.Assert.areEqual(WinJS.Binding.getValue(obj, "nonExisting", undefined));
+      LiveUnit.Assert.areEqual(WinJS.Binding.getValue(obj, "pages.page2", undefined));
+    }
+
 };
 
 LiveUnit.registerTestClass('CorsicaTests.BindingDeclTests');


### PR DESCRIPTION
This allows implementers of custom initializer functions to use the getValue method to extract source values instead of writing their own version of the function over and over.
