### PR TITLE
Allow addClassOneTime to handle Array values returned from source property

### DIFF
--- a/src/js/binding/declarative.js
+++ b/src/js/binding/declarative.js
@@ -541,7 +541,7 @@
     function addClassOneTime(source, sourceProperties, dest) {
         /// <signature helpKeyword="WinJS.Binding.addClassOneTime">
         /// <summary locid="WinJS.Binding.addClassOneTime">
-        /// Adds a class on the destination element to the value of the source property
+        /// Adds a class or Array list of classes on the destination element to the value of the source property
         /// </summary>
         /// <param name="source" type="Object" locid="WinJS.Binding.addClassOneTime:source">
         /// The source object.
@@ -554,7 +554,12 @@
         /// </param>
         /// </signature>
         dest = requireSupportedForProcessing(dest);
-        dest.classList.add(getValue(source, sourceProperties));
+        var value = getValue(source, sourceProperties);
+        if (Array.isArray(value)) {
+            dest.classList.add.apply(dest.classList, value);
+        } else {
+            dest.classList.add(value);
+        }
     }
 
     var defaultBindImpl = converter(function defaultBind_passthrough(v) { return v; });

--- a/tests/binding/binding-decl.js
+++ b/tests/binding/binding-decl.js
@@ -2361,6 +2361,27 @@ CorsicaTests.BindingDeclTests = function () {
            then(complete, errorHandler);
         
     };
+
+    this.testAddClassOneTimeWithArray = function (complete) {
+
+      var mydiv = document.createElement("div");
+      var cleanup = parent(mydiv);
+      mydiv.classList.add("originalClass");
+      mydiv.setAttribute("id", "mydiv");
+      mydiv.setAttribute("data-win-bind", "textContent:names WinJS.Binding.addClassOneTime");
+
+      var obj = WinJS.Binding.as({ names: ["Sally", "Nelly"] });
+      var bindingDone = WinJS.Binding.processAll(mydiv, obj);
+
+      bindingDone.
+         then(post).then(function () {
+           LiveUnit.Assert.areEqual("originalClass Sally Nelly", mydiv.className);
+         })
+         .then(null, errorHandler).
+         then(cleanup).
+         then(complete, errorHandler);
+
+    };
 };
 
 LiveUnit.registerTestClass('CorsicaTests.BindingDeclTests');


### PR DESCRIPTION
That allows us to apply multiple classes to be added at once.

Use case: You want to style elements in a calendar when they have appointments in the past,future and today in different styles.

```
var CalenderEntry = 
get classNames() {
      classes = []
      classes.push(this.hasAppointments? "appointments" : "noAppointments");
      today = new Date();
      today.setHours(0, 0, 0, 0);
      thisDate = new Date(this.startDate);
      thisDate.setHours(0, 0, 0, 0);
      if (this.startDate < today) {
        classes.push("past");
      } else if (this.startDate > today) {
        classes.push("future");
      } else {
        classes.push("today");
      }
      return classes;
    }

// In HTML
<div class="entry" data-win-bind="className:classNames addClassOneTime">
```
