### PR TITLE
Need to set getString = _getStringJS in the test.html

### DIFF
--- a/projects/WWAUnitTestsApp/default.html
+++ b/projects/WWAUnitTestsApp/default.html
@@ -43,12 +43,6 @@
                     a.target = "";
                 });
             }
-            if (frame.contentWindow.WinJS) {
-                // Ensure that the strings are loaded from the .strings.js files, normally in local context 
-                //  strings are expected to be loaded from the PRI
-                //
-                frame.contentWindow.WinJS.Resources.getString = frame.contentWindow.WinJS.Resources._getStringJS;
-            }
         };
 
         window.onerror = function () {

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -134,6 +134,7 @@
         window.addEventListener("error", function () { return true; });                                                     \r\n\
         window.removeEventListener("load", QUnit.load);                                                                     \r\n\
         window.addEventListener("load", function () { MSApp.execUnsafeLocalFunction(function () { QUnit.load(); }); });     \r\n\
+        WinJS.Resources.getString = WinJS.Resources._getStringJS;                                                           \r\n\
     }                                                                                                                       \r\n\
     </script>                                                                                                               \r\n\
     <!-- Test references -->                                                                                                \r\n\


### PR DESCRIPTION
Need to set getString = _getStringJS in the test.html, not from the outside of the iframe which is too late for "expected exceptions" to work in tests.
