### PR TITLE
fixed failing FlipView tests

### DIFF
--- a/src/js/WinJS/Controls/FlipView/_PageManager.js
+++ b/src/js/WinJS/Controls/FlipView/_PageManager.js
@@ -1762,7 +1762,6 @@ define([
                 _forEachPage: function (callback) {
                     var curr = this._prevMarker;
                     do {
-                        console.log("enter while loop");
                         if (callback(curr)) {
                             break;
                         }


### PR DESCRIPTION
Looks like the bug was due to an error in Safari's JIT compiler.  Unable to repro after change.
