### PR TITLE
Fix issue with refactored build to use the correct module name

### DIFF
--- a/tasks/options/requirejs.js
+++ b/tasks/options/requirejs.js
@@ -315,10 +315,11 @@
         if (!options.dir) {
             options.name = options.name || key;
             var target = options.target || options.name;
+            var name = options.name;
             options.out = outputBase + target + ".js";
             options.wrap = {
                 start: header(target, options.exclude || []),
-                end: footer(target),
+                end: footer(name),
             };
         }
         return buildConfig;


### PR DESCRIPTION
Fix issue with refactored build to use the correct module name in the final 'require' statement.

Fixes #481
