### PR TITLE
Binding declarative processing broken for skipRoot=false

### DIFF
--- a/src/js/WinJS/Binding/_Declarative.js
+++ b/src/js/WinJS/Binding/_Declarative.js
@@ -215,7 +215,7 @@ define([
         var selector = "[data-win-bind],[data-win-control]";
         var elements = baseElement.querySelectorAll(selector);
         var neg;
-        if (!skipRoot && baseElement.getAttribute("data-win-bind")) {
+        if (!skipRoot && (baseElement.getAttribute("data-win-bind") || baseElement.winControl)) {
             neg = baseElement;
         }
 


### PR DESCRIPTION
Binding declarative processing is not correctly respecting isDeclarativeControlContainer when on the root node passed to the processor (and skipRoot is false).

Closes #32
