### PR TITLE
Add a private global variable to track version

### DIFF
--- a/src/js/WinJS/Core/_BaseUtils.js
+++ b/src/js/WinJS/Core/_BaseUtils.js
@@ -473,7 +473,9 @@ define([
         _traceAsyncOperationStarting: _Trace._traceAsyncOperationStarting,
         _traceAsyncOperationCompleted: _Trace._traceAsyncOperationCompleted,
         _traceAsyncCallbackStarting: _Trace._traceAsyncCallbackStarting,
-        _traceAsyncCallbackCompleted: _Trace._traceAsyncCallbackCompleted
+        _traceAsyncCallbackCompleted: _Trace._traceAsyncCallbackCompleted,
+
+        _version: "$(build.version)"
     });
 
     _Base.Namespace._moduleDefine(exports, "WinJS", {


### PR DESCRIPTION
This variable is useful for sites which measure usage of various JS
libraries. WinJS did not have a globally exposed variable, so sites know
if one uses WinJS, but not the version with accuracy. This change
leverages the existing string replace grunt task and exposes
WinJS.Utilities._version
