### PR TITLE
Fix Menu Command with Flyout

### DIFF
--- a/src/js/WinJS/Controls/Menu/_Command.js
+++ b/src/js/WinJS/Controls/Menu/_Command.js
@@ -448,7 +448,7 @@ define([
                     if (!this.hidden && !this.disabled && !this._disposed) {
                         if (this._type === _Constants.typeToggle) {
                             this.selected = !this.selected;
-                        } else if (this._type === _Constants.typeFlyout) {
+                        } else if (this._type === _Constants.typeFlyout && this._flyout.hidden) {
                             MenuCommand._activateFlyoutCommand(this);
                         }
 


### PR DESCRIPTION
When using a menu command with a flyout in a toolbar (as overflow for content or otherwise) the flyout is shown on hover. 
Invoking the `MenuCommand._activateFlyoutCommand` again when the flyout is shown causes an exception. 
This change checks if the flyout associated with the `MenuCommand` is hidden before calling that function.