### PR TITLE
Makes the menu command aware of flyout positioning

### DIFF
--- a/src/js/WinJS/Controls/Menu/_Command.js
+++ b/src/js/WinJS/Controls/Menu/_Command.js
@@ -501,7 +501,10 @@ define([
                                 c();
                             }, false);
 
-                            subFlyout.show(menuCommand, "right");
+                             // Decide which side we can show the flyout on.
+                            var position = Math.abs(document.body.clientWidth - menuCommand.element.getBoundingClientRect().right) < 100 ? 'left' : 'right'
+
+                            subFlyout.show(menuCommand, position);
                         } else {
                             // Could not change command to activated state.
                             e();


### PR DESCRIPTION
This makes the `MenuCommand` check it's position relative to the edge of the document before showing a flyout on the right. If the menu is all the way on the right side of the screen, showing the flyout to right is not a good option. 
This change adds a check to see if more than 100px are available to the right of the `MenuCommand`