### PR TITLE
Update _Declarative.js

### DIFF
--- a/src/js/WinJS/Binding/_Declarative.js
+++ b/src/js/WinJS/Binding/_Declarative.js
@@ -382,13 +382,7 @@ define([
                 bindable = source._getObservable();
             }
             if (bindable) {
-                var counter = 0;
                 var workerResult = bindWorker(_Data.as(source), sourceProperties, function (v) {
-                    if (++counter === 1) {
-                        if (v === initialValue) {
-                            return;
-                        }
-                    }
                     var found = checkBindingToken(_DomWeakRefTable._getWeakRefElement(ref), bindingId);
                     if (found) {
                         nestedSet(found, destProperties, convert(requireSupportedForProcessing(v)));

--- a/tests/Binding/binding-decl.ts
+++ b/tests/Binding/binding-decl.ts
@@ -931,6 +931,33 @@ module CorsicaTests {
                 then(cleanup).
                 then(complete, errorHandler);
         };
+        
+        testSimpleWithConverterWithUndefinedProperty = function (complete) {
+            var mydiv = document.createElement('div');
+            var cleanup = parent(mydiv);
+            mydiv.setAttribute('id', 'mydiv');
+            // The non-exiting tooltip should trigger the myaction also and set it to an empty string ""
+            mydiv.setAttribute('data-win-bind', 'textContent:name myaction;title:tooltip myaction');
+
+            window['myaction'] = WinJS.Binding.converter(function (v) {
+                return v ? v : "";
+            });
+            WinJS.Binding.initializer(window['myaction']);
+
+            var obj = { name: 'Sally', width: 100 };
+            var bindingDone = WinJS.Binding.processAll(mydiv, WinJS.Binding.as(obj));
+
+            bindingDone.
+                then(post).
+                then(function () {
+                    delete window['myaction'];
+                    LiveUnit.Assert.areEqual("Sally", mydiv.textContent);
+                    LiveUnit.Assert.areEqual("", mydiv.title);
+                }).
+                then(null, errorHandler).
+                then(cleanup).
+                then(complete, errorHandler);
+        };
 
         testSimpleWithConverterDefaultInitializer = function (complete) {
             var mydiv = document.createElement('div');


### PR DESCRIPTION
Fixes #1118: Remove check for initialValue being undefined before calling converter function.

This check did not allow the binding of `undefined` values which make a valid usecase for bound models with undefined properties that should not end up in the markup as `undefined` output.