### PR TITLE
Fix #1254: Tab Navigation Exception in Hub

### DIFF
--- a/src/js/WinJS/Controls/Hub.js
+++ b/src/js/WinJS/Controls/Hub.js
@@ -885,7 +885,7 @@ define([
                     // Helper method to skip keyboarding and clicks
 
                     while (element && element !== _Global.document.body) {
-                        if (element.classList.contains("win-interactive")) {
+                        if (element.classList && element.classList.contains("win-interactive")) {
                             return true;
                         }
                         element = element.parentElement;


### PR DESCRIPTION
adding undefined check for classList