### PR TITLE
composer package descriptor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "winjs/winjs",
+  "type": "library",
+  "description": "WinJS is a set of JavaScript toolkits that allow developers to build applications using HTML/JS/CSS technology.",
+  "keywords": [
+    "html",
+    "css",
+    "js",
+    "front-end",
+    "framework",
+    "web"
+  ],
+  "homepage": "http://try.buildwinjs.com/",
+  "authors": [
+    {
+      "name": "Microsoft Corporation and other contributors",
+      "homepage": "https://github.com/winjs/winjs/graphs/contributors"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/winjs/winjs/issues"
+  },
+  "license": "MIT",
+  "extra": {
+    "branch-alias": {
+      "dev-master": "4.0.x-dev"
+    }
+  }
+}


### PR DESCRIPTION
bootstrap has. Why not to support the same in WinJS? Actually it is something i need for my project to manage all same way.