### PR TITLE
WinJS.Application should fire "backclick" for the Win10 AppView back button

### DIFF
--- a/src/js/WinJS/Application.js
+++ b/src/js/WinJS/Application.js
@@ -689,8 +689,7 @@ define([
                     // the taskbar's tablet mode button, and the optional window frame back button.
                     var navManager = _WinRT.Windows.UI.Core.SystemNavigationManager.getForCurrentView();
                     navManager.addEventListener("backrequested", hardwareButtonBackPressed);
-                }
-                else if (_WinRT.Windows.Phone.UI.Input.HardwareButtons) {
+                } else if (_WinRT.Windows.Phone.UI.Input.HardwareButtons) {
                     // For WP 8.1
                     _WinRT.Windows.Phone.UI.Input.HardwareButtons.addEventListener("backpressed", hardwareButtonBackPressed);
                 }
@@ -729,8 +728,7 @@ define([
                 if (_WinRT.Windows.UI.Core.SystemNavigationManager) {
                     var navManager = _WinRT.Windows.UI.Core.SystemNavigationManager.getForCurrentView();
                     navManager.removeEventListener("backrequested", hardwareButtonBackPressed);
-                }
-                else if (_WinRT.Windows.Phone.UI.Input.HardwareButtons) {
+                } else if (_WinRT.Windows.Phone.UI.Input.HardwareButtons) {
                     _WinRT.Windows.Phone.UI.Input.HardwareButtons.removeEventListener("backpressed", hardwareButtonBackPressed);
                 }
 

--- a/src/js/WinJS/Application.js
+++ b/src/js/WinJS/Application.js
@@ -683,8 +683,15 @@ define([
                     settingsPane.addEventListener("commandsrequested", commandsRequested);
                 }
 
-                // Code in WinJS.Application for phone. This integrates WinJS.Application into the hardware back button.
-                if (_WinRT.Windows.Phone.UI.Input.HardwareButtons) {
+                // This integrates WinJS.Application into the hardware or OS-provided back button.
+                if (_WinRT.Windows.UI.Core.SystemNavigationManager) {
+                    // On Win10 this accomodates hardware buttons (phone), 
+                    // the taskbar's tablet mode button, and the optional window frame back button.
+                    var navManager = _WinRT.Windows.UI.Core.SystemNavigationManager.getForCurrentView();
+                    navManager.addEventListener("backrequested", hardwareButtonBackPressed);
+                }
+                else if (_WinRT.Windows.Phone.UI.Input.HardwareButtons) {
+                    // For WP 8.1
                     _WinRT.Windows.Phone.UI.Input.HardwareButtons.addEventListener("backpressed", hardwareButtonBackPressed);
                 }
 
@@ -719,8 +726,11 @@ define([
                     settingsPane.removeEventListener("commandsrequested", commandsRequested);
                 }
 
-                // Code in WinJS.Application for phone. This integrates WinJS.Application into the hardware back button.
-                if (_WinRT.Windows.Phone.UI.Input.HardwareButtons) {
+                if (_WinRT.Windows.UI.Core.SystemNavigationManager) {
+                    var navManager = _WinRT.Windows.UI.Core.SystemNavigationManager.getForCurrentView();
+                    navManager.removeEventListener("backrequested", hardwareButtonBackPressed);
+                }
+                else if (_WinRT.Windows.Phone.UI.Input.HardwareButtons) {
                     _WinRT.Windows.Phone.UI.Input.HardwareButtons.removeEventListener("backpressed", hardwareButtonBackPressed);
                 }
 

--- a/src/js/WinJS/Core/_WinRT.js
+++ b/src/js/WinJS/Core/_WinRT.js
@@ -38,6 +38,7 @@ define([
         "Windows.UI.ApplicationSettings.SettingsCommand",
         "Windows.UI.ApplicationSettings.SettingsPane",
         "Windows.UI.Core.AnimationMetrics",
+        "Windows.UI.Core.SystemNavigationManager",
         "Windows.UI.Input.EdgeGesture",
         "Windows.UI.Input.EdgeGestureKind",
         "Windows.UI.Input.PointerPoint",


### PR DESCRIPTION
This fixes #1323.