### PR TITLE
Use newer travis infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
 - '0.11.14'
 before_script:


### PR DESCRIPTION
I noticed travis was running in a slower mode
<img width="681" alt="screen shot 2015-08-07 at 12 29 55 am" src="https://cloud.githubusercontent.com/assets/4303/9130856/229e9cd4-3c9b-11e5-8ce3-ca4272372da5.png">

This one line change enables the faster Docker based runs of travis-ci.