### PR TITLE
Make Pivot Item width more accurate

### DIFF
--- a/src/less/styles-pivot.less
+++ b/src/less/styles-pivot.less
@@ -192,15 +192,15 @@ html.win-hoverable .win-pivot {
     position: absolute;
     top: 0;
     bottom: 0;
-    /* Since the surface is 3x in width, 33% here means the size of the viewport. */
-    width: 33%;
-    left: 33%;
+    /* Since the surface is 3x in width, 33.3% here means the size of the viewport. */
+    width: 33.3%;
+    left: 33.3%;
 }
 
 .win-pivot-item {
     .RTL( {
         left: auto;
-        right: 33%;
+        right: 33.3%;
     }
 
     );


### PR DESCRIPTION
The previous width of '33%' meant that a noticeable border was left on the pivot item's right side (or left if using a RTL layout).
This change makes the pivot item occupy 99.9%  of the container, rather than just 99%.