### PR TITLE
Add `getNavManager` helper to avoid errors when running in Windows 8 compat mode.

### DIFF
--- a/src/js/WinJS/Application.js
+++ b/src/js/WinJS/Application.js
@@ -663,6 +663,13 @@ define([
         dispatchEvent({ type: edgyCanceledET, kind: eventObject.kind });
     }
 
+    function getNavManager() {
+        // Use `Object.is` environment inference to avoid a critical error
+        // in `getForCurrentView` when running in Windows 8 compat mode.
+        var manager = _WinRT.Windows.UI.Core.SystemNavigationManager;
+        return (Object.is && manager) ? manager.getForCurrentView() : null;
+    }
+
     function register() {
         if (!registered) {
             registered = true;
@@ -684,10 +691,10 @@ define([
                 }
 
                 // This integrates WinJS.Application into the hardware or OS-provided back button.
-                if (_WinRT.Windows.UI.Core.SystemNavigationManager) {
-                    // On Win10 this accomodates hardware buttons (phone), 
+                var navManager = getNavManager();
+                if (navManager) {
+                    // On Win10 this accomodates hardware buttons (phone),
                     // the taskbar's tablet mode button, and the optional window frame back button.
-                    var navManager = _WinRT.Windows.UI.Core.SystemNavigationManager.getForCurrentView();
                     navManager.addEventListener("backrequested", hardwareButtonBackPressed);
                 } else if (_WinRT.Windows.Phone.UI.Input.HardwareButtons) {
                     // For WP 8.1
@@ -725,8 +732,8 @@ define([
                     settingsPane.removeEventListener("commandsrequested", commandsRequested);
                 }
 
-                if (_WinRT.Windows.UI.Core.SystemNavigationManager) {
-                    var navManager = _WinRT.Windows.UI.Core.SystemNavigationManager.getForCurrentView();
+                var navManager = getNavManager();
+                if (navManager) {
                     navManager.removeEventListener("backrequested", hardwareButtonBackPressed);
                 } else if (_WinRT.Windows.Phone.UI.Input.HardwareButtons) {
                     _WinRT.Windows.Phone.UI.Input.HardwareButtons.removeEventListener("backpressed", hardwareButtonBackPressed);


### PR DESCRIPTION
This PR addresses issue #1479.