### PR TITLE
Added print and share icons (was Added two more icons to AppbarIcons)

### DIFF
--- a/src/js/WinJS/Controls/AppBar/_Icon.js
+++ b/src/js/WinJS/Controls/AppBar/_Icon.js
@@ -171,6 +171,8 @@ define([
                     "fontincrease",
                     "fontsize",
                     "cellphone",
+                    "print",
+                    "share",
                     "reshare",
                     "tag",
                     "repeatone",

--- a/src/strings/af-za/Microsoft.WinJS.resjson
+++ b/src/strings/af-za/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/af-za/Microsoft.WinJS.resjson
+++ b/src/strings/af-za/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/am-et/Microsoft.WinJS.resjson
+++ b/src/strings/am-et/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/am-et/Microsoft.WinJS.resjson
+++ b/src/strings/am-et/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ar-sa/Microsoft.WinJS.resjson
+++ b/src/strings/ar-sa/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ar-sa/Microsoft.WinJS.resjson
+++ b/src/strings/ar-sa/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/as-in/Microsoft.WinJS.resjson
+++ b/src/strings/as-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/as-in/Microsoft.WinJS.resjson
+++ b/src/strings/as-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/az-latn-az/Microsoft.WinJS.resjson
+++ b/src/strings/az-latn-az/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/az-latn-az/Microsoft.WinJS.resjson
+++ b/src/strings/az-latn-az/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/be-by/Microsoft.WinJS.resjson
+++ b/src/strings/be-by/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/be-by/Microsoft.WinJS.resjson
+++ b/src/strings/be-by/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/bg-bg/Microsoft.WinJS.resjson
+++ b/src/strings/bg-bg/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/bg-bg/Microsoft.WinJS.resjson
+++ b/src/strings/bg-bg/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/bn-bd/Microsoft.WinJS.resjson
+++ b/src/strings/bn-bd/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/bn-bd/Microsoft.WinJS.resjson
+++ b/src/strings/bn-bd/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/bn-in/Microsoft.WinJS.resjson
+++ b/src/strings/bn-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/bn-in/Microsoft.WinJS.resjson
+++ b/src/strings/bn-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/bs-latn-ba/Microsoft.WinJS.resjson
+++ b/src/strings/bs-latn-ba/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/bs-latn-ba/Microsoft.WinJS.resjson
+++ b/src/strings/bs-latn-ba/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ca-es-valencia/Microsoft.WinJS.resjson
+++ b/src/strings/ca-es-valencia/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ca-es-valencia/Microsoft.WinJS.resjson
+++ b/src/strings/ca-es-valencia/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ca-es/Microsoft.WinJS.resjson
+++ b/src/strings/ca-es/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ca-es/Microsoft.WinJS.resjson
+++ b/src/strings/ca-es/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/chr-cher-us/Microsoft.WinJS.resjson
+++ b/src/strings/chr-cher-us/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/chr-cher-us/Microsoft.WinJS.resjson
+++ b/src/strings/chr-cher-us/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/cs-cz/Microsoft.WinJS.resjson
+++ b/src/strings/cs-cz/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/cs-cz/Microsoft.WinJS.resjson
+++ b/src/strings/cs-cz/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/cy-gb/Microsoft.WinJS.resjson
+++ b/src/strings/cy-gb/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/cy-gb/Microsoft.WinJS.resjson
+++ b/src/strings/cy-gb/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/da-dk/Microsoft.WinJS.resjson
+++ b/src/strings/da-dk/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/da-dk/Microsoft.WinJS.resjson
+++ b/src/strings/da-dk/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/de-de/Microsoft.WinJS.resjson
+++ b/src/strings/de-de/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/de-de/Microsoft.WinJS.resjson
+++ b/src/strings/de-de/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/el-gr/Microsoft.WinJS.resjson
+++ b/src/strings/el-gr/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/el-gr/Microsoft.WinJS.resjson
+++ b/src/strings/el-gr/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/en-gb/Microsoft.WinJS.resjson
+++ b/src/strings/en-gb/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/en-gb/Microsoft.WinJS.resjson
+++ b/src/strings/en-gb/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/en-us/Microsoft.WinJS.resjson
+++ b/src/strings/en-us/Microsoft.WinJS.resjson
@@ -431,6 +431,10 @@
     "_ui/appBarIcons/fontsize.comment":                   "{Locked=qps-ploc,qps-plocm}",
     "ui/appBarIcons/cellphone":                           "\uE1C9", // group:Communications
     "_ui/appBarIcons/cellphone.comment":                  "{Locked=qps-ploc,qps-plocm}",
+    "ui/appBarIcons/print":                               "\uE749", // group:Communications
+    "_ui/appBarIcons/print.comment":                      "{Locked=qps-ploc,qps-plocm}",
+    "ui/appBarIcons/share":                               "\uE72D", // group:Communications
+    "_ui/appBarIcons/share.comment":                      "{Locked=qps-ploc,qps-plocm}",
     "ui/appBarIcons/reshare":                             "\uE1CA", // group:Communications
     "_ui/appBarIcons/reshare.comment":                    "{Locked=qps-ploc,qps-plocm}",
     "ui/appBarIcons/tag":                                 "\uE1CB", // group:Data

--- a/src/strings/es-es/Microsoft.WinJS.resjson
+++ b/src/strings/es-es/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/es-es/Microsoft.WinJS.resjson
+++ b/src/strings/es-es/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/es-mx/Microsoft.WinJS.resjson
+++ b/src/strings/es-mx/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/es-mx/Microsoft.WinJS.resjson
+++ b/src/strings/es-mx/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/et-ee/Microsoft.WinJS.resjson
+++ b/src/strings/et-ee/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/et-ee/Microsoft.WinJS.resjson
+++ b/src/strings/et-ee/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/eu-es/Microsoft.WinJS.resjson
+++ b/src/strings/eu-es/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/eu-es/Microsoft.WinJS.resjson
+++ b/src/strings/eu-es/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/fa-ir/Microsoft.WinJS.resjson
+++ b/src/strings/fa-ir/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/fa-ir/Microsoft.WinJS.resjson
+++ b/src/strings/fa-ir/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/fi-fi/Microsoft.WinJS.resjson
+++ b/src/strings/fi-fi/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/fi-fi/Microsoft.WinJS.resjson
+++ b/src/strings/fi-fi/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/fil-ph/Microsoft.WinJS.resjson
+++ b/src/strings/fil-ph/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/fil-ph/Microsoft.WinJS.resjson
+++ b/src/strings/fil-ph/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/fr-ca/Microsoft.WinJS.resjson
+++ b/src/strings/fr-ca/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/fr-ca/Microsoft.WinJS.resjson
+++ b/src/strings/fr-ca/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/fr-fr/Microsoft.WinJS.resjson
+++ b/src/strings/fr-fr/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/fr-fr/Microsoft.WinJS.resjson
+++ b/src/strings/fr-fr/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ga-ie/Microsoft.WinJS.resjson
+++ b/src/strings/ga-ie/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ga-ie/Microsoft.WinJS.resjson
+++ b/src/strings/ga-ie/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/gd-gb/Microsoft.WinJS.resjson
+++ b/src/strings/gd-gb/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/gd-gb/Microsoft.WinJS.resjson
+++ b/src/strings/gd-gb/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/gl-es/Microsoft.WinJS.resjson
+++ b/src/strings/gl-es/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/gl-es/Microsoft.WinJS.resjson
+++ b/src/strings/gl-es/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/gu-in/Microsoft.WinJS.resjson
+++ b/src/strings/gu-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/gu-in/Microsoft.WinJS.resjson
+++ b/src/strings/gu-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ha-latn-ng/Microsoft.WinJS.resjson
+++ b/src/strings/ha-latn-ng/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ha-latn-ng/Microsoft.WinJS.resjson
+++ b/src/strings/ha-latn-ng/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/he-il/Microsoft.WinJS.resjson
+++ b/src/strings/he-il/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/he-il/Microsoft.WinJS.resjson
+++ b/src/strings/he-il/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/hi-in/Microsoft.WinJS.resjson
+++ b/src/strings/hi-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/hi-in/Microsoft.WinJS.resjson
+++ b/src/strings/hi-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/hr-hr/Microsoft.WinJS.resjson
+++ b/src/strings/hr-hr/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/hr-hr/Microsoft.WinJS.resjson
+++ b/src/strings/hr-hr/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/hu-hu/Microsoft.WinJS.resjson
+++ b/src/strings/hu-hu/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/hu-hu/Microsoft.WinJS.resjson
+++ b/src/strings/hu-hu/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/hy-am/Microsoft.WinJS.resjson
+++ b/src/strings/hy-am/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/hy-am/Microsoft.WinJS.resjson
+++ b/src/strings/hy-am/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/id-id/Microsoft.WinJS.resjson
+++ b/src/strings/id-id/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/id-id/Microsoft.WinJS.resjson
+++ b/src/strings/id-id/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ig-ng/Microsoft.WinJS.resjson
+++ b/src/strings/ig-ng/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ig-ng/Microsoft.WinJS.resjson
+++ b/src/strings/ig-ng/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/is-is/Microsoft.WinJS.resjson
+++ b/src/strings/is-is/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/is-is/Microsoft.WinJS.resjson
+++ b/src/strings/is-is/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/it-it/Microsoft.WinJS.resjson
+++ b/src/strings/it-it/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/it-it/Microsoft.WinJS.resjson
+++ b/src/strings/it-it/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ja-jp/Microsoft.WinJS.resjson
+++ b/src/strings/ja-jp/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ja-jp/Microsoft.WinJS.resjson
+++ b/src/strings/ja-jp/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ka-ge/Microsoft.WinJS.resjson
+++ b/src/strings/ka-ge/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ka-ge/Microsoft.WinJS.resjson
+++ b/src/strings/ka-ge/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/kk-kz/Microsoft.WinJS.resjson
+++ b/src/strings/kk-kz/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/kk-kz/Microsoft.WinJS.resjson
+++ b/src/strings/kk-kz/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/km-kh/Microsoft.WinJS.resjson
+++ b/src/strings/km-kh/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/km-kh/Microsoft.WinJS.resjson
+++ b/src/strings/km-kh/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/kn-in/Microsoft.WinJS.resjson
+++ b/src/strings/kn-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/kn-in/Microsoft.WinJS.resjson
+++ b/src/strings/kn-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ko-kr/Microsoft.WinJS.resjson
+++ b/src/strings/ko-kr/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ko-kr/Microsoft.WinJS.resjson
+++ b/src/strings/ko-kr/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/kok-in/Microsoft.WinJS.resjson
+++ b/src/strings/kok-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/kok-in/Microsoft.WinJS.resjson
+++ b/src/strings/kok-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ku-arab-iq/Microsoft.WinJS.resjson
+++ b/src/strings/ku-arab-iq/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ku-arab-iq/Microsoft.WinJS.resjson
+++ b/src/strings/ku-arab-iq/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ky-kg/Microsoft.WinJS.resjson
+++ b/src/strings/ky-kg/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ky-kg/Microsoft.WinJS.resjson
+++ b/src/strings/ky-kg/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/lb-lu/Microsoft.WinJS.resjson
+++ b/src/strings/lb-lu/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/lb-lu/Microsoft.WinJS.resjson
+++ b/src/strings/lb-lu/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/lo-la/Microsoft.WinJS.resjson
+++ b/src/strings/lo-la/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/lo-la/Microsoft.WinJS.resjson
+++ b/src/strings/lo-la/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/lt-lt/Microsoft.WinJS.resjson
+++ b/src/strings/lt-lt/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/lt-lt/Microsoft.WinJS.resjson
+++ b/src/strings/lt-lt/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/lv-lv/Microsoft.WinJS.resjson
+++ b/src/strings/lv-lv/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/lv-lv/Microsoft.WinJS.resjson
+++ b/src/strings/lv-lv/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/mi-nz/Microsoft.WinJS.resjson
+++ b/src/strings/mi-nz/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/mi-nz/Microsoft.WinJS.resjson
+++ b/src/strings/mi-nz/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/mk-mk/Microsoft.WinJS.resjson
+++ b/src/strings/mk-mk/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/mk-mk/Microsoft.WinJS.resjson
+++ b/src/strings/mk-mk/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ml-in/Microsoft.WinJS.resjson
+++ b/src/strings/ml-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ml-in/Microsoft.WinJS.resjson
+++ b/src/strings/ml-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/mn-mn/Microsoft.WinJS.resjson
+++ b/src/strings/mn-mn/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/mn-mn/Microsoft.WinJS.resjson
+++ b/src/strings/mn-mn/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/mr-in/Microsoft.WinJS.resjson
+++ b/src/strings/mr-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/mr-in/Microsoft.WinJS.resjson
+++ b/src/strings/mr-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ms-my/Microsoft.WinJS.resjson
+++ b/src/strings/ms-my/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ms-my/Microsoft.WinJS.resjson
+++ b/src/strings/ms-my/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/mt-mt/Microsoft.WinJS.resjson
+++ b/src/strings/mt-mt/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/mt-mt/Microsoft.WinJS.resjson
+++ b/src/strings/mt-mt/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/nb-no/Microsoft.WinJS.resjson
+++ b/src/strings/nb-no/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/nb-no/Microsoft.WinJS.resjson
+++ b/src/strings/nb-no/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ne-np/Microsoft.WinJS.resjson
+++ b/src/strings/ne-np/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ne-np/Microsoft.WinJS.resjson
+++ b/src/strings/ne-np/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/nl-nl/Microsoft.WinJS.resjson
+++ b/src/strings/nl-nl/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/nl-nl/Microsoft.WinJS.resjson
+++ b/src/strings/nl-nl/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/nn-no/Microsoft.WinJS.resjson
+++ b/src/strings/nn-no/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/nn-no/Microsoft.WinJS.resjson
+++ b/src/strings/nn-no/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/nso-za/Microsoft.WinJS.resjson
+++ b/src/strings/nso-za/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/nso-za/Microsoft.WinJS.resjson
+++ b/src/strings/nso-za/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/or-in/Microsoft.WinJS.resjson
+++ b/src/strings/or-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/or-in/Microsoft.WinJS.resjson
+++ b/src/strings/or-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/pa-arab-pk/Microsoft.WinJS.resjson
+++ b/src/strings/pa-arab-pk/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/pa-arab-pk/Microsoft.WinJS.resjson
+++ b/src/strings/pa-arab-pk/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/pa-in/Microsoft.WinJS.resjson
+++ b/src/strings/pa-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/pa-in/Microsoft.WinJS.resjson
+++ b/src/strings/pa-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/pl-pl/Microsoft.WinJS.resjson
+++ b/src/strings/pl-pl/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/pl-pl/Microsoft.WinJS.resjson
+++ b/src/strings/pl-pl/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/prs-af/Microsoft.WinJS.resjson
+++ b/src/strings/prs-af/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/prs-af/Microsoft.WinJS.resjson
+++ b/src/strings/prs-af/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/pt-br/Microsoft.WinJS.resjson
+++ b/src/strings/pt-br/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/pt-br/Microsoft.WinJS.resjson
+++ b/src/strings/pt-br/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/pt-pt/Microsoft.WinJS.resjson
+++ b/src/strings/pt-pt/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/pt-pt/Microsoft.WinJS.resjson
+++ b/src/strings/pt-pt/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/quc-latn-gt/Microsoft.WinJS.resjson
+++ b/src/strings/quc-latn-gt/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/quc-latn-gt/Microsoft.WinJS.resjson
+++ b/src/strings/quc-latn-gt/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/quz-pe/Microsoft.WinJS.resjson
+++ b/src/strings/quz-pe/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/quz-pe/Microsoft.WinJS.resjson
+++ b/src/strings/quz-pe/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ro-ro/Microsoft.WinJS.resjson
+++ b/src/strings/ro-ro/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ro-ro/Microsoft.WinJS.resjson
+++ b/src/strings/ro-ro/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ru-ru/Microsoft.WinJS.resjson
+++ b/src/strings/ru-ru/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ru-ru/Microsoft.WinJS.resjson
+++ b/src/strings/ru-ru/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/rw-rw/Microsoft.WinJS.resjson
+++ b/src/strings/rw-rw/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/rw-rw/Microsoft.WinJS.resjson
+++ b/src/strings/rw-rw/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sd-arab-pk/Microsoft.WinJS.resjson
+++ b/src/strings/sd-arab-pk/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sd-arab-pk/Microsoft.WinJS.resjson
+++ b/src/strings/sd-arab-pk/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/si-lk/Microsoft.WinJS.resjson
+++ b/src/strings/si-lk/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/si-lk/Microsoft.WinJS.resjson
+++ b/src/strings/si-lk/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sk-sk/Microsoft.WinJS.resjson
+++ b/src/strings/sk-sk/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sk-sk/Microsoft.WinJS.resjson
+++ b/src/strings/sk-sk/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sl-si/Microsoft.WinJS.resjson
+++ b/src/strings/sl-si/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sl-si/Microsoft.WinJS.resjson
+++ b/src/strings/sl-si/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sq-al/Microsoft.WinJS.resjson
+++ b/src/strings/sq-al/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sq-al/Microsoft.WinJS.resjson
+++ b/src/strings/sq-al/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sr-cyrl-ba/Microsoft.WinJS.resjson
+++ b/src/strings/sr-cyrl-ba/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sr-cyrl-ba/Microsoft.WinJS.resjson
+++ b/src/strings/sr-cyrl-ba/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sr-cyrl-rs/Microsoft.WinJS.resjson
+++ b/src/strings/sr-cyrl-rs/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sr-cyrl-rs/Microsoft.WinJS.resjson
+++ b/src/strings/sr-cyrl-rs/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sr-latn-rs/Microsoft.WinJS.resjson
+++ b/src/strings/sr-latn-rs/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sr-latn-rs/Microsoft.WinJS.resjson
+++ b/src/strings/sr-latn-rs/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sv-se/Microsoft.WinJS.resjson
+++ b/src/strings/sv-se/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sv-se/Microsoft.WinJS.resjson
+++ b/src/strings/sv-se/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sw-ke/Microsoft.WinJS.resjson
+++ b/src/strings/sw-ke/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/sw-ke/Microsoft.WinJS.resjson
+++ b/src/strings/sw-ke/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ta-in/Microsoft.WinJS.resjson
+++ b/src/strings/ta-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ta-in/Microsoft.WinJS.resjson
+++ b/src/strings/ta-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/te-in/Microsoft.WinJS.resjson
+++ b/src/strings/te-in/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/te-in/Microsoft.WinJS.resjson
+++ b/src/strings/te-in/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/tg-cyrl-tj/Microsoft.WinJS.resjson
+++ b/src/strings/tg-cyrl-tj/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/tg-cyrl-tj/Microsoft.WinJS.resjson
+++ b/src/strings/tg-cyrl-tj/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/th-th/Microsoft.WinJS.resjson
+++ b/src/strings/th-th/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/th-th/Microsoft.WinJS.resjson
+++ b/src/strings/th-th/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ti-et/Microsoft.WinJS.resjson
+++ b/src/strings/ti-et/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ti-et/Microsoft.WinJS.resjson
+++ b/src/strings/ti-et/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/tk-tm/Microsoft.WinJS.resjson
+++ b/src/strings/tk-tm/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/tk-tm/Microsoft.WinJS.resjson
+++ b/src/strings/tk-tm/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/tn-za/Microsoft.WinJS.resjson
+++ b/src/strings/tn-za/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/tn-za/Microsoft.WinJS.resjson
+++ b/src/strings/tn-za/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/tr-tr/Microsoft.WinJS.resjson
+++ b/src/strings/tr-tr/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/tr-tr/Microsoft.WinJS.resjson
+++ b/src/strings/tr-tr/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/tt-ru/Microsoft.WinJS.resjson
+++ b/src/strings/tt-ru/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/tt-ru/Microsoft.WinJS.resjson
+++ b/src/strings/tt-ru/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ug-cn/Microsoft.WinJS.resjson
+++ b/src/strings/ug-cn/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ug-cn/Microsoft.WinJS.resjson
+++ b/src/strings/ug-cn/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/uk-ua/Microsoft.WinJS.resjson
+++ b/src/strings/uk-ua/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/uk-ua/Microsoft.WinJS.resjson
+++ b/src/strings/uk-ua/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ur-pk/Microsoft.WinJS.resjson
+++ b/src/strings/ur-pk/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/ur-pk/Microsoft.WinJS.resjson
+++ b/src/strings/ur-pk/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/uz-latn-uz/Microsoft.WinJS.resjson
+++ b/src/strings/uz-latn-uz/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/uz-latn-uz/Microsoft.WinJS.resjson
+++ b/src/strings/uz-latn-uz/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/vi-vn/Microsoft.WinJS.resjson
+++ b/src/strings/vi-vn/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/vi-vn/Microsoft.WinJS.resjson
+++ b/src/strings/vi-vn/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/wo-sn/Microsoft.WinJS.resjson
+++ b/src/strings/wo-sn/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/wo-sn/Microsoft.WinJS.resjson
+++ b/src/strings/wo-sn/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/xh-za/Microsoft.WinJS.resjson
+++ b/src/strings/xh-za/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/xh-za/Microsoft.WinJS.resjson
+++ b/src/strings/xh-za/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/yo-ng/Microsoft.WinJS.resjson
+++ b/src/strings/yo-ng/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/yo-ng/Microsoft.WinJS.resjson
+++ b/src/strings/yo-ng/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/zh-cn/Microsoft.WinJS.resjson
+++ b/src/strings/zh-cn/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/zh-cn/Microsoft.WinJS.resjson
+++ b/src/strings/zh-cn/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/zh-hk/Microsoft.WinJS.resjson
+++ b/src/strings/zh-hk/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/zh-hk/Microsoft.WinJS.resjson
+++ b/src/strings/zh-hk/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/zh-tw/Microsoft.WinJS.resjson
+++ b/src/strings/zh-tw/Microsoft.WinJS.resjson
@@ -262,6 +262,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/zh-tw/Microsoft.WinJS.resjson
+++ b/src/strings/zh-tw/Microsoft.WinJS.resjson
@@ -263,7 +263,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/zu-za/Microsoft.WinJS.resjson
+++ b/src/strings/zu-za/Microsoft.WinJS.resjson
@@ -260,6 +260,8 @@
   "ui/appBarIcons/fontincrease": "",
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
+  "ui/appBarIcons/print": "",
+  "ui/appBarIcons/share": ""
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/src/strings/zu-za/Microsoft.WinJS.resjson
+++ b/src/strings/zu-za/Microsoft.WinJS.resjson
@@ -261,7 +261,7 @@
   "ui/appBarIcons/fontsize": "",
   "ui/appBarIcons/cellphone": "",
   "ui/appBarIcons/print": "",
-  "ui/appBarIcons/share": ""
+  "ui/appBarIcons/share": "",
   "ui/appBarIcons/reshare": "",
   "ui/appBarIcons/tag": "",
   "ui/appBarIcons/repeatone": "",

--- a/typings/winjs/winjs.d.ts
+++ b/typings/winjs/winjs.d.ts
@@ -2542,6 +2542,8 @@ declare module WinJS.UI {
         fontincrease,
         fontsize,
         cellphone,
+        print,
+        share,
         reshare,
         tag,
         repeatone,
@@ -2810,8 +2812,8 @@ declare module WinJS.UI {
 
     //#region Interfaces
 
-    /** 
-     * Define the shape of a Command object to be used in AppBar and ToolBar controls. 
+    /**
+     * Define the shape of a Command object to be used in AppBar and ToolBar controls.
     **/
     export interface ICommand {
         //#region Methods
@@ -4066,7 +4068,7 @@ declare module WinJS.UI {
         **/
         placement: string;
 
-        /** 
+        /**
          * Display options for the AppBar when closed.
         **/
         static ClosedDisplayMode: {
@@ -4088,7 +4090,7 @@ declare module WinJS.UI {
             full: string;
         };
 
-        /** 
+        /**
          * Display options for AppBar placement in relation to the main view.
         */
         static Placement: {
@@ -5397,7 +5399,7 @@ declare module WinJS.UI {
         dispose(): void;
 
         /**
-         * Forces the Hub to update its layout. 
+         * Forces the Hub to update its layout.
          * Use this function when making the Hub visible again after you've set its style.display property to "none” or after style changes have been made that affect the size of the HubSections.
         **/
         forceLayout(): void;
@@ -5954,13 +5956,13 @@ declare module WinJS.UI {
         onselectionchanging(eventInfo: CustomEvent): void;
 
         /**
-         * Raised when the header's visibility property changes. 
+         * Raised when the header's visibility property changes.
          * @param eventInfo An object that contains information about the event. The detail property of this object contains the following sub-properties: detail.visible.
         **/
         onheadervisibilitychanged(eventInfo: CustomEvent): void;
 
         /**
-         * Raised when the footer's visibility property changes. 
+         * Raised when the footer's visibility property changes.
          * @param eventInfo An object that contains information about the event. The detail property of this object contains the following sub-properties: detail.visible.
         **/
         onfootervisibilitychanged(eventInfo: CustomEvent): void;
@@ -6883,7 +6885,7 @@ declare module WinJS.UI {
         //#region Events
 
         /**
-         * This API supports the Windows Library for JavaScript infrastructure and is not intended to be used directly from your code. 
+         * This API supports the Windows Library for JavaScript infrastructure and is not intended to be used directly from your code.
          * Use NavBarContainer.oninvoked instead.
         **/
         oninvoked: any;
@@ -8001,7 +8003,7 @@ declare module WinJS.UI {
 
         //# region Events
 
-        /** 
+        /**
          * Raised when a SplitViewCommand has been invoked.
          * @param eventInfo An object that contains information about the event.
         **/
@@ -8443,7 +8445,7 @@ declare module WinJS.UI {
         public dispose(): void;
 
         /**
-         * Forces the ToolBar to update its layout. 
+         * Forces the ToolBar to update its layout.
          * Use this function when the window did not change size, but the ToolBar itself did.
         **/
         public forceLayout(): void;
@@ -9947,7 +9949,7 @@ declare module WinJS.Utilities {
         push(...items: T[]): number;
 
         /**
-         * Reverses the elements in an Array. 
+         * Reverses the elements in an Array.
         **/
         reverse(): T[];
 
@@ -9956,7 +9958,7 @@ declare module WinJS.Utilities {
         **/
         shift(): T;
 
-        /** 
+        /**
          * Returns a section of an array.
          * @param start The beginning of the specified portion of the array.
          * @param end The end of the specified portion of the array.
@@ -10019,14 +10021,14 @@ declare module WinJS.Utilities {
 
         /**
          * Calls a defined callback function on each element of an array, and returns an array that contains the results.
-         * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array. 
+         * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
         **/
         map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
 
         /**
-         * Returns the elements of an array that meet the condition specified in a callback function. 
-         * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array. 
+         * Returns the elements of an array that meet the condition specified in a callback function.
+         * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
         **/
         filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
@@ -10044,15 +10046,15 @@ declare module WinJS.Utilities {
         **/
         reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
 
-        /** 
+        /**
          * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-         * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
+         * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
         **/
         reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
-        /** 
+        /**
          * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-         * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
+         * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
         **/
         reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;


### PR DESCRIPTION
This replaces #1428 without changing older WinJS.d.ts files, sorry for doing complete pull request. 
Changes in typings/winjs/winjs.d.ts  are only the added print and share and some trailing spaces which were removed from VSCode, hope that is ok. @AmazingJaze