### PR TITLE
Fix color emojis. Add "Segoe UI Emoji" (back?) to base font-family values.

### DIFF
--- a/src/less/font-definitions.less
+++ b/src/less/font-definitions.less
@@ -14,7 +14,7 @@
 }
 
 .win-font-family-list() {
-    font-family: "Segoe UI", sans-serif, "Segoe MDL2 Assets", "Symbols";
+    font-family: "Segoe UI", sans-serif, "Segoe MDL2 Assets", "Symbols", "Segoe UI Emoji";
 }
 
 //

--- a/src/less/styles-pivot.less
+++ b/src/less/styles-pivot.less
@@ -46,7 +46,7 @@
 
     .win-pivot-title {
         #flex > .flex(@shrink: 0);
-        font-family: "Segoe UI", sans-serif, "Segoe MDL2 Assets", "Symbols";
+        font-family: "Segoe UI", sans-serif, "Segoe MDL2 Assets", "Symbols", "Segoe UI Emoji";
         font-size: 15px;
         font-weight: bold;
         white-space: nowrap;


### PR DESCRIPTION
Fixes #1509. Moving a Windows app to WinJS 4 regresses color emoji support, because Segoe UI Emoji isn't in the list of font fallbacks. This PR adds it back.