### PR TITLE
Update bower definition so works properly to wiredep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "name": "Microsoft Corporation and other contributors",
     "homepage": "https://github.com/winjs/winjs/graphs/contributors"
   }],
-  "main": ["js/ui.js", "css/ui-dark.css", "fonts/Symbols.ttf"],
+  "main": ["js/base.js","js/ui.js", "css/ui-dark.css", "fonts/Symbols.ttf"],
   "dependencies": {
   }
 }


### PR DESCRIPTION
With this update to the bower.json - wiredep (https://github.com/taptapship/wiredep) will correctly inject the two required JS files into the source.
