### PR TITLE
Fix tooltip behavior for AppBarCommand, Menu

### DIFF
--- a/src/js/WinJS/Controls/AppBar/_Command.js
+++ b/src/js/WinJS/Controls/AppBar/_Command.js
@@ -242,9 +242,6 @@ define([
 
                         // Update aria-label
                         this._element.setAttribute("aria-label", this.label);
-
-                        // Check if we need to suppress the tooltip
-                        this._testIdenticalTooltip();
                     }
                 },
 
@@ -387,9 +384,6 @@ define([
                         if (this._tooltipControl) {
                             this._tooltipControl.innerHTML = this._tooltip;
                         }
-
-                        // Check if we need to suppress the tooltip
-                        this._testIdenticalTooltip();
                     }
                 },
 
@@ -552,11 +546,6 @@ define([
                     }
                 },
 
-                // Private
-                _testIdenticalTooltip: function AppBarCommand_testIdenticalToolTip() {
-                    this._hideIfFullSize = (this._label === this._tooltip);
-                },
-
                 _createContent: function AppBarCommand_createContent() {
                     // Make sure there's an element
                     if (!this._element) {
@@ -631,12 +620,6 @@ define([
                     // Attach a tooltip - Note: we're going to stomp on it's setControl so we don't have to make another DOM element to hang it off of.
                     // This private _tooltipControl attribute is used by other pieces, changing the name could break them.
                     this._tooltipControl = new Tooltip.Tooltip(this._element);
-                    var that = this;
-                    this._tooltipControl.addEventListener("beforeopen", function () {
-                        if (that._hideIfFullSize && !_Overlay._Overlay._getParentControlUsingClassName(that._element.parentElement, _Constants.reducedClass)) {
-                            that._tooltipControl.close();
-                        }
-                    }, false);
                 },
 
                 _setSection: function AppBarCommand_setSection(section) {

--- a/src/js/WinJS/Controls/CommandingSurface/_CommandingSurface.ts
+++ b/src/js/WinJS/Controls/CommandingSurface/_CommandingSurface.ts
@@ -1480,6 +1480,7 @@ export class _CommandingSurface {
             type: (originalCommand.type === _Constants.typeContent ? _Constants.typeFlyout : originalCommand.type) || _Constants.typeButton,
             disabled: originalCommand.disabled,
             flyout: originalCommand.flyout,
+            tooltip: originalCommand.tooltip,
             beforeInvoke: () => {
                 // Save the command that was selected
                 this._chosenCommand = <_Command.ICommand>(menuCommand["_originalICommand"]);

--- a/src/js/WinJS/Controls/Menu/_Command.d.ts
+++ b/src/js/WinJS/Controls/Menu/_Command.d.ts
@@ -114,6 +114,11 @@ export declare class MenuCommand {
     selected: boolean;
 
     /**
+     * Gets or sets the tooltip of the command.
+    **/
+    tooltip: string;
+
+    /**
      * Gets the type of the command.
     **/
     type: string;

--- a/src/js/WinJS/Controls/Menu/_Command.js
+++ b/src/js/WinJS/Controls/Menu/_Command.js
@@ -11,8 +11,9 @@ define([
     '../../Utilities/_Control',
     '../../Utilities/_ElementUtilities',
     '../_LegacyAppBar/_Constants',
-    '../Flyout/_Overlay'
-], function menuCommandInit(exports, _Global, _Base, _ErrorFromName, _Resources, Promise, _Control, _ElementUtilities, _Constants, _Overlay) {
+    '../Flyout/_Overlay',
+    '../Tooltip'
+], function menuCommandInit(exports, _Global, _Base, _ErrorFromName, _Resources, Promise, _Control, _ElementUtilities, _Constants, _Overlay, Tooltip) {
     "use strict";
 
     _Base.Namespace._moduleDefine(exports, "WinJS.UI", {
@@ -186,6 +187,9 @@ define([
 
                         // Update aria-label
                         this._element.setAttribute("aria-label", this.label);
+                        
+                        // Check if we need to suppress the tooltip
+                        this._testIdenticalTooltip();
                     }
                 },
 
@@ -254,6 +258,24 @@ define([
 
                         // Remember it
                         this._flyout = value;
+                    }
+                },
+
+                /// <field type="String" locid="WinJS.UI.AppBarCommand.tooltip" helpKeyword="WinJS.UI.AppBarCommand.tooltip">Gets or sets the tooltip text of the AppBarCommand.</field>
+                tooltip: {
+                    get: function () {
+                        return this._tooltip;
+                    },
+                    set: function (value) {
+                        this._tooltip = value;
+
+                        // Update already-constructed tooltips. Separators and content commands won't have these:
+                        if (this._tooltipControl) {
+                            this._tooltipControl.innerHTML = this._tooltip;
+                        }
+                        
+                        // Check if we need to suppress the tooltip
+                        this._testIdenticalTooltip();
                     }
                 },
 
@@ -357,6 +379,10 @@ define([
                         return;
                     }
                     this._disposed = true;
+                    
+                    if (this._tooltipControl) {
+                        this._tooltipControl.dispose();
+                    }
                 },
 
                 addEventListener: function (type, listener, useCapture) {
@@ -390,6 +416,10 @@ define([
                 },
 
                 // Private properties
+                _testIdenticalTooltip: function AppBarCommand_testIdenticalToolTip() {
+                    this._hideIfFullSize = (this._label === this._tooltip);
+                },
+                
                 _createSeparator: function MenuCommand_createSeparator() {
                     // Make sure there's an input element
                     if (!this._element) {
@@ -431,6 +461,15 @@ define([
                     this._labelSpan = this._toggleSpan.nextElementSibling;
                     this._flyoutSpan = this._labelSpan.nextElementSibling;
 
+                    // Attach a tooltip - Note: we're going to stomp on it's setControl so we don't have to make another DOM element to hang it off of.
+                    // This private _tooltipControl attribute is used by other pieces, changing the name could break them.
+                    this._tooltipControl = new Tooltip.Tooltip(this._element);
+                    var that = this;
+                    this._tooltipControl.addEventListener("beforeopen", function () {
+                        if (that._hideIfFullSize) {
+                            that._tooltipControl.close();
+                        }
+                    }, false);
                 },
                 _sendEvent: function MenuCommand_sendEvent(eventName, detail) {
                     if (!this._disposed) {

--- a/src/js/WinJS/Controls/Menu/_Command.js
+++ b/src/js/WinJS/Controls/Menu/_Command.js
@@ -187,9 +187,6 @@ define([
 
                         // Update aria-label
                         this._element.setAttribute("aria-label", this.label);
-                        
-                        // Check if we need to suppress the tooltip
-                        this._testIdenticalTooltip();
                     }
                 },
 
@@ -273,9 +270,6 @@ define([
                         if (this._tooltipControl) {
                             this._tooltipControl.innerHTML = this._tooltip;
                         }
-                        
-                        // Check if we need to suppress the tooltip
-                        this._testIdenticalTooltip();
                     }
                 },
 
@@ -416,10 +410,6 @@ define([
                 },
 
                 // Private properties
-                _testIdenticalTooltip: function AppBarCommand_testIdenticalToolTip() {
-                    this._hideIfFullSize = (this._label === this._tooltip);
-                },
-                
                 _createSeparator: function MenuCommand_createSeparator() {
                     // Make sure there's an input element
                     if (!this._element) {
@@ -464,12 +454,6 @@ define([
                     // Attach a tooltip - Note: we're going to stomp on it's setControl so we don't have to make another DOM element to hang it off of.
                     // This private _tooltipControl attribute is used by other pieces, changing the name could break them.
                     this._tooltipControl = new Tooltip.Tooltip(this._element);
-                    var that = this;
-                    this._tooltipControl.addEventListener("beforeopen", function () {
-                        if (that._hideIfFullSize) {
-                            that._tooltipControl.close();
-                        }
-                    }, false);
                 },
                 _sendEvent: function MenuCommand_sendEvent(eventName, detail) {
                     if (!this._disposed) {


### PR DESCRIPTION
This fix is to comply with the behavior of the XAML UI like for example "Photos" app.

* Remove tooltip suppress check in AppBarCommand - This is not needed anymore.
* Add Tooltip to Menu, CommandingSurface - I need this like "Photos" app