### PR TITLE
fix(listview): fix app crash when we reload a page with a listview

### DIFF
--- a/src/js/WinJS/Controls/ListView.js
+++ b/src/js/WinJS/Controls/ListView.js
@@ -1189,6 +1189,9 @@ define([
 
                 _forceLayoutImpl: function ListView_forceLayoutImpl(viewChange) {
                     var that = this;
+                    if (!this._versionManager) {
+                        return;
+                    }
                     this._versionManager.unlocked.then(function () {
                         that._writeProfilerMark("_forceLayoutImpl viewChange(" + viewChange + "),info");
 


### PR DESCRIPTION
On WIndows 10, when we reload (navigate again) a page with a listview, the app crash with this error : 

    /dist/winjs/js/ui.js 0x800a138f - JavaScript runtime error: Unable to get property 'unlocked' of undefined or null reference

The current commit fixes the bug.