### PR TITLE
Skip toggle for xbox. Fixes #1526

### DIFF
--- a/src/js/WinJS/XYFocus.ts
+++ b/src/js/WinJS/XYFocus.ts
@@ -686,6 +686,10 @@ function _isInInactiveToggleModeContainer(element: HTMLElement) {
 }
 
 function _isToggleMode(element: HTMLElement) {
+    if (_ElementUtilities.hasClass(_Global.document.body, ClassNames.xboxPlatform)) {
+        return false;
+    }
+
     if (_ElementUtilities.hasClass(element, ClassNames.toggleMode)) {
         return true;
     }


### PR DESCRIPTION
Currently, on xbox, the user has to press A button twice to pop out the virtual keyboard and then press B button twice to enable navigation through the page again. This change fixes this issue.