### PR TITLE
Make WinJS QUnit tests runnable in Win10 UWP enviornment. (WebAppsAndFrameWorks team)

### DIFF
--- a/tasks/test.js
+++ b/tasks/test.js
@@ -179,8 +179,12 @@
     <script>                                                                                                                \r\n\
     if (window.MSApp) {                                                                                                     \r\n\
         window.addEventListener("error", function () { return true; });                                                     \r\n\
-        window.removeEventListener("load", QUnit.load);                                                                     \r\n\
-        window.addEventListener("load", function () { MSApp.execUnsafeLocalFunction(function () { QUnit.load(); }); });     \r\n\
+        if(window.MSApp.execUnsafeLocalFunction) { /* This API was removed in Windows 10 */                                 \r\n\
+            window.removeEventListener("load", QUnit.load);                                                                 \r\n\
+            window.addEventListener("load", function () {                                                                   \r\n\
+                MSApp.execUnsafeLocalFunction(function () { QUnit.load(); });                                               \r\n\
+            });                                                                                                             \r\n\
+        }                                                                                                                   \r\n\
         WinJS.Resources.getString = WinJS.Resources._getStringJS;                                                           \r\n\
     }                                                                                                                       \r\n\
     </script>                                                                                                               \r\n\


### PR DESCRIPTION
WebAppsAndFrameworks team needs this to run WinJS unit tests inside of WWA environment as part of their lab test runs.

This PR updates test files to check if MSApp.execUnsafeLocalFunction exsists before calling it.

The WinJS team used to run tests in the browser and in Win 8.1 WWA's. As such the WinJS tests have some expectation of the Windows 8 SafterHTML content security policy when they detect they are inside of a WWA.

In Windows 8, WWA's Content Security Policy required that any callback functions registered to JavaScript event handlers first be sanitized by the function defined at window.MSApp.execUnsafeLocalFunction() 

In Windows 10 UWP apps, the security policy has changed and window.MSApp.execUnsafeLocalFunction is no longer required or even defined. However, each WinJS test page tries to pass QUnit.load into window.MSApp.execUnsafeLocalFunction, when they detect they are running in WWA, and they immediately crash because the function doesn't exist.

Ideally this commit would be merged both into the WinJS master branch, and backported as a patch to the stable WinJS 4.4.0 release.

// CC @jdalton 