### PR TITLE
Fix, wrong AppBar position when switching the on-screen keybord

### DIFF
--- a/src/js/WinJS/Controls/AppBar/_AppBar.ts
+++ b/src/js/WinJS/Controls/AppBar/_AppBar.ts
@@ -564,9 +564,13 @@ export class AppBar {
     }
 
     private _handleHidingKeyboard() {
-        // Make sure AppBar has the correct offsets since it could have been displaced by the IHM.
-        this._adjustedOffsets = this._computeAdjustedOffsets();
-        this._commandingSurface.deferredDomUpate();
+        var duration = keyboardInfo._animationShowLength + keyboardInfo._scrollTimeout;
+        Promise.timeout(duration).then(
+            () => {
+                // Make sure AppBar has the correct offsets since it could have been displaced by the IHM.
+                this._adjustedOffsets = this._computeAdjustedOffsets();
+                this._commandingSurface.deferredDomUpate();
+            });
     }
 
     private _computeAdjustedOffsets() {


### PR DESCRIPTION
Fixes a problem with the AppBar when switching between the different types of on-screen keybords. On some point the AppBar is shown in the middle of the screen or other unusual positions. 