### PR TITLE
#1636 SplitView on open pane is moved over top toolbar

### DIFF
--- a/src/less/styles-splitview.less
+++ b/src/less/styles-splitview.less
@@ -96,7 +96,7 @@
 
             @pane-left: {
                 .win-splitview-panewrapper {
-                    position: absolute;
+                    position: static;
                     top: 0;
                     left: 0;
                     right: auto;


### PR DESCRIPTION
for issue #1638 