### PR TITLE
Fixes faulty "PointerCancel" event registration in ListView.

### DIFF
--- a/src/js/WinJS/Controls/ListView.js
+++ b/src/js/WinJS/Controls/ListView.js
@@ -1685,7 +1685,7 @@ define([
                         modeHandler("PointerUp"),
                         modeHandler("LostPointerCapture"),
                         modeHandler("MSHoldVisual", true),
-                        modeHandler("PointerCancel", true),
+                        modeHandler("PointerCancel"),
                         modeHandler("DragStart"),
                         modeHandler("DragOver"),
                         modeHandler("DragEnter"),


### PR DESCRIPTION
WinJS ListView attempts to register for "PointerCancel" event, but only the "pointercancel" event is supported in all modern browsers, so the event never gets registered.
Today there is no direct impact from this bug, because the ListView relies on "PointerCancel" or "lostpointercapture" events to clean up UI state if a user on a touch device presses down on a listview item but then drags their finger to  scroll the listview items.
Yoday that user behavior will result in both "pointercancel" and "lostpointercapture" events being fired synchronously.
However, there is a proposed change that Chrome and Edge may move to implement where the "lostpointercapture" event may not fire because pointer capture will no longer be guaranteed to happen synchronously.
Once this change takes effect the ListView will no longer be guaranteed to recieve "lostpointercapture" events and will fail to clean up state correctly, unless this "pointercanel" event registration is fixed.

// CC @llongley let me know if I can provide further clarification. 