### PR TITLE
Update readme to remove nonworking link to winjs playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ grunt
 Refer to http://winjs.azurewebsites.net/#status for the current status of the unit tests and the list of known issues.
 
 # Try WinJS
-Check out our online playground at http://www.buildwinjs.com/playground/
-
-The old playground is still available at http://winjs.azurewebsites.net/
+Check out our online playground at http://winjs.azurewebsites.net/
 
 # Follow Us
 Twitter https://twitter.com/BuildWinJS  


### PR DESCRIPTION
There's no use keeping around the nonworking link, if the azure site works just fine.